### PR TITLE
feat: added extension list

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,49 @@ AnyCable, k6, WebSockets, and Yabeda](https://evilmartians.com/chronicles/real-t
 - [k6 Extensions](https://grafana.com/docs/k6/latest/extensions/)
 - [GitHub Topic: xk6](https://github.com/topics/xk6) - Explore k6 extensions tagged with the xk6 label.
 
+### Official
+
+- [xk6-client-tracing](https://github.com/grafana/xk6-client-tracing) - Client for load testing distributed tracing backends.
+- [xk6-dashboard](https://github.com/grafana/xk6-dashboard) - Create a web-based metrics dashboard.
+- [xk6-disruptor](https://github.com/grafana/xk6-disruptor) - Inject faults to test 💣.
+- [xk6-exec](https://github.com/grafana/xk6-exec) - Run external commands.
+- [xk6-kubernetes](https://github.com/grafana/xk6-kubernetes) - Interact with Kubernetes clusters.
+- [xk6-loki](https://github.com/grafana/xk6-loki) - Client for load testing Loki.
+- [xk6-notification](https://github.com/grafana/xk6-notification) - Create notifications.
+- [xk6-output-influxdb](https://github.com/grafana/xk6-output-influxdb) - Export results to InfluxDB v2.
+- [xk6-output-kafka](https://github.com/grafana/xk6-output-kafka) - Export k6 results in real-time to Kafka.
+- [xk6-output-timescaledb](https://github.com/grafana/xk6-output-timescaledb) - Export k6 results to TimescaleDB.
+- [xk6-sql](https://github.com/grafana/xk6-sql) - Load-test SQL Servers (PostgreSQL, MySQL and SQLite3 for now).
+- [xk6-ssh](https://github.com/grafana/xk6-ssh) - SSH.
+
+### Community
+
+- [xk6-cable](https://github.com/anycable/xk6-cable) - Test Action Cable and AnyCable functionality.
+- [xk6-client-prometheus-remote](https://github.com/grafana/xk6-client-prometheus-remote) - Test Prometheus Remote Write performance.
+- [xk6-coap](https://github.com/golioth/xk6-coap) - Interact with Constrained Application Protocol endpoints.
+- [xk6-dotenv](https://github.com/szkiba/xk6-dotenv) - Load env vars from a .env file.
+- [xk6-ethereum](https://github.com/distribworks/xk6-ethereum) - K6 extension for ethereum protocols.
+- [xk6-faker](https://github.com/szkiba/xk6-faker) - Generate random fake data.
+- [xk6-file](https://github.com/avitalique/xk6-file) - Write files.
+- [xk6-g0](https://github.com/szkiba/xk6-g0) - Write k6 tests in golang.
+- [xk6-kafka](https://github.com/mostafa/xk6-kafka) - Load-test Apache Kafka. Includes support for Avro messages.
+- [xk6-kv](https://github.com/oleiade/xk6-kv) - Share key-value data between VUs.
+- [xk6-mock](https://github.com/szkiba/xk6-mock) - Mock HTTP(S) servers.
+- [xk6-mqtt](https://github.com/pmalhaire/xk6-mqtt) - MQTT extension.
+- [xk6-nats](https://github.com/ydarias/xk6-nats) - Provides NATS support for k6 tests.
+- [xk6-opentelemetry](https://github.com/thmshmm/xk6-opentelemetry) - Generate OpenTelemetry signals from within your test scripts.
+- [xk6-output-elasticsearch](https://github.com/elastic/xk6-output-elasticsearch) - Export results to Elasticsearch 8.x.
+- [xk6-output-prometheus-pushgateway](https://github.com/martymarron/xk6-output-prometheus-pushgateway) - Export results to Prometheus pushgateway.
+- [xk6-output-statsd](https://github.com/LeonAdato/xk6-output-statsd) - Enables real-time output of test metrics to a StatsD service.
+- [xk6-output-timestream](https://github.com/leonyork/xk6-output-timestream) - Export results to AWS Timestream.
+- [xk6-playwright](https://github.com/nicholasvuono/xk6-playwright) - Browser automation and end-to-end web testing using Playwright.
+- [xk6-prometheus](https://github.com/szkiba/xk6-prometheus) - Prometheus HTTP exporter for k6.
+- [xk6-prompt](https://github.com/Juandavi1/xk6-prompt) - Support for input arguments via UI.
+- [xk6-sse](https://github.com/phymbert/xk6-sse) - A k6 extension for Server-Sent Events (SSE).
+- [xk6-tcp](https://github.com/NAlexandrov/xk6-tcp) - Send data to TCP port.
+- [xk6-top](https://github.com/szkiba/xk6-top) - Updating the current k6 metrics summaries on the terminal during the test run.
+- [xk6-ts](https://github.com/grafana/xk6-ts) - Add TypeScript support for k6.
+
 ## Related
 
 - [How They Load Test](https://github.com/aliesbelik/how-they-load) - A collection of resources on how companies around the world perform load testing.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,6 @@ AnyCable, k6, WebSockets, and Yabeda](https://evilmartians.com/chronicles/real-t
 - [xk6-sse](https://github.com/phymbert/xk6-sse) - A k6 extension for Server-Sent Events (SSE).
 - [xk6-tcp](https://github.com/NAlexandrov/xk6-tcp) - Send data to TCP port.
 - [xk6-top](https://github.com/szkiba/xk6-top) - Updating the current k6 metrics summaries on the terminal during the test run.
-- [xk6-ts](https://github.com/grafana/xk6-ts) - Add TypeScript support for k6.
 
 ## Related
 

--- a/README.md
+++ b/README.md
@@ -134,8 +134,9 @@ AnyCable, k6, WebSockets, and Yabeda](https://evilmartians.com/chronicles/real-t
 
 - [k6 Extensions](https://grafana.com/docs/k6/latest/extensions/)
 - [GitHub Topic: xk6](https://github.com/topics/xk6) - Explore k6 extensions tagged with the xk6 label.
+- [Extension Registry](https://grafana.com/docs/k6/latest/extensions/explanations/extensions-registry/) - Curated listing of k6 extensions.
 
-### [Official](https://grafana.com/docs/k6/latest/extensions/explanations/extensions-registry/#extension-tiers)
+### Official
 
 - [xk6-client-tracing](https://github.com/grafana/xk6-client-tracing) - Client for load testing distributed tracing backends.
 - [xk6-disruptor](https://github.com/grafana/xk6-disruptor) - Inject faults to test 💣.
@@ -149,7 +150,7 @@ AnyCable, k6, WebSockets, and Yabeda](https://evilmartians.com/chronicles/real-t
 - [xk6-sql](https://github.com/grafana/xk6-sql) - Load-test SQL Servers (PostgreSQL, MySQL and SQLite3 for now).
 - [xk6-ssh](https://github.com/grafana/xk6-ssh) - SSH.
 
-### [Community](https://grafana.com/docs/k6/latest/extensions/explanations/extensions-registry/#extension-tiers)
+### Community
 
 - [xk6-cable](https://github.com/anycable/xk6-cable) - Test Action Cable and AnyCable functionality.
 - [xk6-client-prometheus-remote](https://github.com/grafana/xk6-client-prometheus-remote) - Test Prometheus Remote Write performance.

--- a/README.md
+++ b/README.md
@@ -147,13 +147,13 @@ AnyCable, k6, WebSockets, and Yabeda](https://evilmartians.com/chronicles/real-t
 - [xk6-output-influxdb](https://github.com/grafana/xk6-output-influxdb) - Export results to InfluxDB v2.
 - [xk6-output-kafka](https://github.com/grafana/xk6-output-kafka) - Export k6 results in real-time to Kafka.
 - [xk6-output-timescaledb](https://github.com/grafana/xk6-output-timescaledb) - Export k6 results to TimescaleDB.
+- [xk6-client-prometheus-remote](https://github.com/grafana/xk6-client-prometheus-remote) - Test Prometheus Remote Write performance.
 - [xk6-sql](https://github.com/grafana/xk6-sql) - Load-test SQL Servers (PostgreSQL, MySQL and SQLite3 for now).
 - [xk6-ssh](https://github.com/grafana/xk6-ssh) - SSH.
 
 ### Community
 
 - [xk6-cable](https://github.com/anycable/xk6-cable) - Test Action Cable and AnyCable functionality.
-- [xk6-client-prometheus-remote](https://github.com/grafana/xk6-client-prometheus-remote) - Test Prometheus Remote Write performance.
 - [xk6-coap](https://github.com/golioth/xk6-coap) - Interact with Constrained Application Protocol endpoints.
 - [xk6-dotenv](https://github.com/szkiba/xk6-dotenv) - Load env vars from a .env file.
 - [xk6-ethereum](https://github.com/distribworks/xk6-ethereum) - K6 extension for ethereum protocols.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ AnyCable, k6, WebSockets, and Yabeda](https://evilmartians.com/chronicles/real-t
 - [k6 Extensions](https://grafana.com/docs/k6/latest/extensions/)
 - [GitHub Topic: xk6](https://github.com/topics/xk6) - Explore k6 extensions tagged with the xk6 label.
 
-### Official
+### [Official](https://grafana.com/docs/k6/latest/extensions/explanations/extensions-registry/#extension-tiers)
 
 - [xk6-client-tracing](https://github.com/grafana/xk6-client-tracing) - Client for load testing distributed tracing backends.
 - [xk6-disruptor](https://github.com/grafana/xk6-disruptor) - Inject faults to test 💣.
@@ -149,7 +149,7 @@ AnyCable, k6, WebSockets, and Yabeda](https://evilmartians.com/chronicles/real-t
 - [xk6-sql](https://github.com/grafana/xk6-sql) - Load-test SQL Servers (PostgreSQL, MySQL and SQLite3 for now).
 - [xk6-ssh](https://github.com/grafana/xk6-ssh) - SSH.
 
-### Community
+### [Community](https://grafana.com/docs/k6/latest/extensions/explanations/extensions-registry/#extension-tiers)
 
 - [xk6-cable](https://github.com/anycable/xk6-cable) - Test Action Cable and AnyCable functionality.
 - [xk6-client-prometheus-remote](https://github.com/grafana/xk6-client-prometheus-remote) - Test Prometheus Remote Write performance.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@ AnyCable, k6, WebSockets, and Yabeda](https://evilmartians.com/chronicles/real-t
 ### Official
 
 - [xk6-client-tracing](https://github.com/grafana/xk6-client-tracing) - Client for load testing distributed tracing backends.
-- [xk6-dashboard](https://github.com/grafana/xk6-dashboard) - Create a web-based metrics dashboard.
 - [xk6-disruptor](https://github.com/grafana/xk6-disruptor) - Inject faults to test 💣.
 - [xk6-exec](https://github.com/grafana/xk6-exec) - Run external commands.
 - [xk6-kubernetes](https://github.com/grafana/xk6-kubernetes) - Interact with Kubernetes clusters.


### PR DESCRIPTION
It is usual for awesome lists that although the list is longer, the list directly contains links to resources. In addition to the GitHub topic search (xk6), it is advisable to add a list of popular extensions.

Extensions supported by Grafana and supported by the community have been placed in separate sections. The community-supported extension list initially contains registered extensions whose repository has ten or more stars. Later, this list will be maintained by the community (in the form of PRs).