### PR TITLE
docs: link xk6-kv to oshokin/xk6-kv in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ AnyCable, k6, WebSockets, and Yabeda](https://evilmartians.com/chronicles/real-t
 - [xk6-file](https://github.com/avitalique/xk6-file) - Write files.
 - [xk6-g0](https://github.com/szkiba/xk6-g0) - Write k6 tests in golang.
 - [xk6-kafka](https://github.com/mostafa/xk6-kafka) - Load-test Apache Kafka. Includes support for Avro messages.
-- [xk6-kv](https://github.com/oleiade/xk6-kv) - Share key-value data between VUs.
+- [xk6-kv](https://github.com/oshokin/xk6-kv) - Share key-value state between VUs. Actively maintained fork: random keys, coordination atomics, snapshots/metrics, TypeScript, pre-built releases.
 - [xk6-mock](https://github.com/szkiba/xk6-mock) - Mock HTTP(S) servers.
 - [xk6-mqtt](https://github.com/pmalhaire/xk6-mqtt) - MQTT extension.
 - [xk6-nats](https://github.com/ydarias/xk6-nats) - Provides NATS support for k6 tests.


### PR DESCRIPTION
## Summary
Points the **xk6-kv** list entry at [github.com/oshokin/xk6-kv](https://github.com/oshokin/xk6-kv).

## Why this repo (and not the original link)
[oleiade/xk6-kv](https://github.com/oleiade/xk6-kv) is the upstream I started from. I opened PRs there (e.g. random-key work) but they stalled: changes were not merged, and the project has not picked up the direction load-test authors keep asking for (safe coordination across VUs, richer KV operations, release ergonomics). This list should send readers somewhere **maintained**, **documented**, and **shipped** (binaries on Releases), not to a dead end.

## How the fork came about (timeline)
1. **First motivation — `randomKey` (and friends)**  
   I needed **prefix-aware random key selection** and related helpers for realistic scenarios (sampling keys, producer/consumer style flows, “pick any pending job” patterns). That did not exist in upstream in the form I needed, so I **forked to implement and iterate quickly** (including follow-ups like key tracking / rebuild for sane performance on large stores).

2. **Then everything else**  
   Once the fork existed, the same load-testing use cases kept pushing the surface area: people do not only need “get/set/list”; they need **atomic** operations so `exists` + `set` races do not duplicate work. That matches real upstream demand, e.g. [oleiade/xk6-kv#13 — Atomic check-and-set / SETNX-style coordination](https://github.com/oleiade/xk6-kv/issues/13) (still open upstream). The fork now implements that class of API (`setIfAbsent`, `compareAndSwap` / `compareAndDelete`, detailed mismatch helpers, `getOrSet`, `swap`, `incrementBy`, `deleteIfExists`, etc.), plus **batch** helpers, **cursor** `scan` / `scanKeys`, **random** `randomKey` / `randomKeys`, **exclusive-ish** helpers like `popRandom` and **lease-style** `claimRandom` with `releaseClaim` / `completeClaim`, **snapshots** (`backup` / `restore`) and **JSONL** import/export, **observability** (`stats` / `reportStats`, optional per-method metrics), **TypeScript** typings, **memory sharding** and **bbolt tuning** knobs, and **structured typed errors** — with CI, e2e-style coverage, and **pre-built k6** artifacts on GitHub Releases so users are not forced to build from source.

## Notes
- I am not asking to remove upstream from the ecosystem; this change only updates **where this curated list sends people** for “xk6-kv” so it matches current maintenance and capabilities.